### PR TITLE
Two fixes for Dancer2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ WriteMakefile(
         'Test::More' => 0,
     },
     PREREQ_PM => {
+        'Ref::Util' => 0,
         #'ABC'              => 1.6,
         #'Foo::Bar::Module' => 5.0401,
     },

--- a/lib/Data/Censor.pm
+++ b/lib/Data/Censor.pm
@@ -5,6 +5,8 @@ use strict;
 use warnings FATAL => 'all';
 use Carp;
 
+use Ref::Util qw/ is_hashref /;
+
 =head1 NAME
 
 Data::Censor - censor sensitive stuff in a data structure
@@ -101,7 +103,7 @@ sub new {
         };
     }
 
-    if (ref $args{replacement_callbacks} eq 'HASH') {
+    if ( is_hashref $args{replacement_callbacks} ) {
         $self->{replacement_callbacks} = $args{replacement_callbacks};
     }
     if (exists $args{replacement}) {
@@ -135,13 +137,11 @@ sub censor {
         return;
     }
 
-    if (ref $data ne 'HASH') {
-        croak('censor expects a hashref');
-    }
+	croak('censor expects a hashref') unless is_hashref $data;
     
     my $censored = 0;
     for my $key (keys %$data) {
-        if (ref $data->{$key} eq 'HASH') {
+        if ( is_hashref $data->{$key} ) {
             $censored += $self->censor($data->{$key}, $recurse_count);
         } elsif (
             ($self->{is_sensitive_field} && $self->{is_sensitive_field}{lc $key})

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -69,4 +69,12 @@ SKIP: {
         "clone_and_censor email not censored (used as object method)");
 }
 
+subtest 'objects as hashes' => sub {
+	my $data = bless {
+		password => 'hush',
+	} => 'MyThing';
 
+	$censor->censor($data);
+
+	isnt $data->{password} => 'hush', 'can process object instances';
+};

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -5,7 +5,7 @@ use warnings FATAL => 'all';
 use Test::More;
 use Data::Censor;
 
-plan tests => 11;
+plan tests => 13;
 
 diag( "Testing Data::Censor $Data::Censor::VERSION, Perl $], $^X" );
 
@@ -78,3 +78,23 @@ subtest 'objects as hashes' => sub {
 
 	isnt $data->{password} => 'hush', 'can process object instances';
 };
+
+
+subtest 'recursive' => sub {
+	my $data = {
+		foo => 1,
+	};
+
+	my $y = {
+		bar => 2,
+		password => 'hush',
+		data => $data,
+	};
+
+	$data->{y} = $y; 
+
+	$censor->censor($data);
+
+	isnt $data->{y}{password} => 'hush', 'password is hidden';
+};
+


### PR DESCRIPTION
1. make the censor recognize and deal with object instances (by using is_hashref instead of `ref eq 'HASH'`
2. detect and deal with recursions a wee bit better.